### PR TITLE
Add support for .uv v2 macros

### DIFF
--- a/bot/src/parser.rs
+++ b/bot/src/parser.rs
@@ -2906,7 +2906,7 @@ impl Replay {
         let version = reader.read_u8()?;
         if version != 1 && version != 2 {
             anyhow::bail!(format!(
-                "invalid uvbot version (got: {version:?}, expect: 1)"
+                "invalid uvbot version (got: {version:?}, expect: 1 or 2)"
             ))
         }
 


### PR DESCRIPTION
Add support for .uv v2 macros with an explicit TPS field to the existing implementation